### PR TITLE
Анимируем фон при переключении экранов

### DIFF
--- a/source/js/modules/full-page-scroll.js
+++ b/source/js/modules/full-page-scroll.js
@@ -1,5 +1,8 @@
 import throttle from 'lodash/throttle';
 
+const backgroundScreen = document.createElement("div");
+const pageContent = document.querySelector(".page-content");
+
 export default class FullPageScroll {
   constructor() {
     this.THROTTLE_TIMEOUT = 1000;
@@ -21,13 +24,10 @@ export default class FullPageScroll {
 
     // for smooth animated appearance of some elements on the page load
     const bodyElement = document.querySelector("body");
-    const pageContent = document.querySelector(".page-content");
-    const backgroundScreen = document.createElement("div");
 
     window.onload = function() {
       bodyElement.classList.add("page-loaded");
-      backgroundScreen.classList.add("background-screen")
-      pageContent.appendChild(backgroundScreen);
+      pageContent.appendChild(backgroundScreen); // for transition between active pages
     }
   }
 
@@ -62,14 +62,23 @@ export default class FullPageScroll {
   }
 
   changeVisibilityDisplay() {
-    this.screenElements.forEach((screen) => {
-      screen.classList.add(`screen--hidden`);
-      screen.classList.remove(`active`);
-    });
-    this.screenElements[this.activeScreen].classList.remove(`screen--hidden`);
+    // Transition between active pages by using background-screen class.
+    // Make a delay for the .screen to switch from .screen--hidden to .active.
+    // During this delay, make .background-screen do its animation job.
+    // Then, get rid of .background-screen in the moment of switching from .screen-hidden to .active
+    // to display the actual screen
+    backgroundScreen.classList.add("background-screen");
     setTimeout(() => {
-      this.screenElements[this.activeScreen].classList.add(`active`);
-    }, 100);
+      this.screenElements.forEach((screen) => {
+        screen.classList.add(`screen--hidden`);
+        screen.classList.remove(`active`);
+      });
+      this.screenElements[this.activeScreen].classList.remove(`screen--hidden`);
+      setTimeout(() => {
+        this.screenElements[this.activeScreen].classList.add(`active`);
+        backgroundScreen.classList.remove("background-screen");
+      }, 100);
+    }, 300);
   }
 
   changeActiveMenuItem() {

--- a/source/js/modules/full-page-scroll.js
+++ b/source/js/modules/full-page-scroll.js
@@ -21,8 +21,13 @@ export default class FullPageScroll {
 
     // for smooth animated appearance of some elements on the page load
     const bodyElement = document.querySelector("body");
+    const pageContent = document.querySelector(".page-content");
+    const backgroundScreen = document.createElement("div");
+
     window.onload = function() {
-      bodyElement.classList.add("page-loaded")
+      bodyElement.classList.add("page-loaded");
+      backgroundScreen.classList.add("background-screen")
+      pageContent.appendChild(backgroundScreen);
     }
   }
 

--- a/source/scss/blocks/screen.scss
+++ b/source/scss/blocks/screen.scss
@@ -312,20 +312,20 @@
 }
 
 .background-screen {
-  background: linear-gradient(rgba(255,0,0,0) 50%, $c-dark 50%);
-  position: absolute;
+  position: fixed;
+  top: 100%;
+  left: 0;
   width: 100%;
   height: 100%;
-  top: 0;
-  left: 0;
-  transition-property: background;
-  transition-duration: 300ms;
-  transition-timing-function: ease-in;
-  background-size: 100% 200%;
+  z-index: 101;
+  transform: translateY(0);
+  background-color: $c-dark;
+  transition: transform 250ms ease-out;
 }
 
-.screen--prizes.active ~ .background-screen {
-  background-position: 100% 100%;
+.screen.active ~ .background-screen {
+  transform: translateY(-100%);
+  z-index: 101;
 }
 
 .screen--game {

--- a/source/scss/blocks/screen.scss
+++ b/source/scss/blocks/screen.scss
@@ -311,8 +311,21 @@
   }
 }
 
-.screen--prizes {
-  background-color: $c-dark;
+.background-screen {
+  background: linear-gradient(rgba(255,0,0,0) 50%, $c-dark 50%);
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  transition-property: background;
+  transition-duration: 300ms;
+  transition-timing-function: ease-in;
+  background-size: 100% 200%;
+}
+
+.screen--prizes.active ~ .background-screen {
+  background-position: 100% 100%;
 }
 
 .screen--game {


### PR DESCRIPTION
При переходе с экрана История на экран Призы, 3D должно заливаться фоном поверх экрана. В этом задании нужно реализовать эффект заливки экрана.

В форке личного проекта создайте ветку module1-task3.
Добавьте блок, который будет находиться под контентом экранов и всегда будет на них присутствовать. Этот блок нужно закрепить в нижней части экрана.
Добавьте два состояния этого блока: в начальном — фон не должно быть видно, в конечном же фон должен заполнить весь экран.
Второе состояние нужно включать, когда соответствующие экраны будут активны.

Решить эту задачу можно как через CSS, так и через JS, на ваше усмотрение.

Фон должен накрывать контент экрана, с которого осуществляется переход. Предыдущий экран не должен исчезать прежде, чем завершится анимация заполнения экрана.


---
:mortar_board: [Анимируем фон при переключении экранов](https://up.htmlacademy.ru/animation/1/user/980311/tasks/4)

:boom: https://htmlacademy-animation.github.io/980311-magic-vacation-1/3/